### PR TITLE
Added option to save to binary format in curvestream example

### DIFF
--- a/Examples/Oscilloscopes/PerformanceScopes/src/CurvestreamExample/CurvestreamExample-IVI-VISA.NET/CurvestreamExample-IVI-VISA.NET/frmMain.Designer.cs
+++ b/Examples/Oscilloscopes/PerformanceScopes/src/CurvestreamExample/CurvestreamExample-IVI-VISA.NET/CurvestreamExample-IVI-VISA.NET/frmMain.Designer.cs
@@ -58,7 +58,8 @@ namespace CurvestreamExample
             this.txtSaveDirectory = new System.Windows.Forms.TextBox();
             this.lblWfmSec = new System.Windows.Forms.Label();
             this.lblWfmPerSec = new System.Windows.Forms.Label();
-            this.cbxSaveToDisk = new System.Windows.Forms.CheckBox();
+            this.cmbxSaveToDisk = new System.Windows.Forms.ComboBox();
+            this.lblSaveToDisk = new System.Windows.Forms.Label();
             this.SuspendLayout();
             // 
             // cmdStartTest
@@ -122,7 +123,7 @@ namespace CurvestreamExample
             // lblSaveDirectory
             // 
             this.lblSaveDirectory.AutoSize = true;
-            this.lblSaveDirectory.Location = new System.Drawing.Point(9, 116);
+            this.lblSaveDirectory.Location = new System.Drawing.Point(9, 121);
             this.lblSaveDirectory.Name = "lblSaveDirectory";
             this.lblSaveDirectory.Size = new System.Drawing.Size(80, 13);
             this.lblSaveDirectory.TabIndex = 7;
@@ -130,7 +131,7 @@ namespace CurvestreamExample
             // 
             // txtSaveDirectory
             // 
-            this.txtSaveDirectory.Location = new System.Drawing.Point(12, 132);
+            this.txtSaveDirectory.Location = new System.Drawing.Point(12, 137);
             this.txtSaveDirectory.Name = "txtSaveDirectory";
             this.txtSaveDirectory.Size = new System.Drawing.Size(242, 20);
             this.txtSaveDirectory.TabIndex = 8;
@@ -155,22 +156,35 @@ namespace CurvestreamExample
             this.lblWfmPerSec.Text = "0";
             this.lblWfmPerSec.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
-            // cbxSaveToDisk
+            // cmbxSaveToDisk
             // 
-            this.cbxSaveToDisk.AutoSize = true;
-            this.cbxSaveToDisk.Location = new System.Drawing.Point(279, 134);
-            this.cbxSaveToDisk.Name = "cbxSaveToDisk";
-            this.cbxSaveToDisk.Size = new System.Drawing.Size(93, 17);
-            this.cbxSaveToDisk.TabIndex = 11;
-            this.cbxSaveToDisk.Text = "Save to Disk?";
-            this.cbxSaveToDisk.UseVisualStyleBackColor = true;
+            this.cmbxSaveToDisk.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbxSaveToDisk.FormattingEnabled = true;
+            this.cmbxSaveToDisk.Items.AddRange(new object[] {
+            "None",
+            "Text (.csv)",
+            "Binary (.dat)"});
+            this.cmbxSaveToDisk.Location = new System.Drawing.Point(260, 136);
+            this.cmbxSaveToDisk.Name = "cmbxSaveToDisk";
+            this.cmbxSaveToDisk.Size = new System.Drawing.Size(94, 21);
+            this.cmbxSaveToDisk.TabIndex = 12;
+            // 
+            // lblSaveToDisk
+            // 
+            this.lblSaveToDisk.AutoSize = true;
+            this.lblSaveToDisk.Location = new System.Drawing.Point(257, 121);
+            this.lblSaveToDisk.Name = "lblSaveToDisk";
+            this.lblSaveToDisk.Size = new System.Drawing.Size(71, 13);
+            this.lblSaveToDisk.TabIndex = 13;
+            this.lblSaveToDisk.Text = "Save to Disk:";
             // 
             // frmMain
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(373, 168);
-            this.Controls.Add(this.cbxSaveToDisk);
+            this.ClientSize = new System.Drawing.Size(373, 172);
+            this.Controls.Add(this.lblSaveToDisk);
+            this.Controls.Add(this.cmbxSaveToDisk);
             this.Controls.Add(this.lblWfmPerSec);
             this.Controls.Add(this.lblWfmSec);
             this.Controls.Add(this.txtSaveDirectory);
@@ -201,7 +215,8 @@ namespace CurvestreamExample
         private System.Windows.Forms.TextBox txtSaveDirectory;
         private System.Windows.Forms.Label lblWfmSec;
         private System.Windows.Forms.Label lblWfmPerSec;
-        private System.Windows.Forms.CheckBox cbxSaveToDisk;
+        private System.Windows.Forms.ComboBox cmbxSaveToDisk;
+        private System.Windows.Forms.Label lblSaveToDisk;
     }
 }
 

--- a/Examples/Oscilloscopes/PerformanceScopes/src/CurvestreamExample/README.md
+++ b/Examples/Oscilloscopes/PerformanceScopes/src/CurvestreamExample/README.md
@@ -1,7 +1,7 @@
 # Curve Stream Example
 Original attribution: Dave W. - Tektronix Applications
 
-This example shows how to use the Curve Streaming feature of MSO/DPO5000/B, DPO7000/C, DSA70000/B/C/D, and MSO70000/C/DX, DPO70000/B/C/D/DX /SX Series Digital Oscilloscopes to stream curves from the oscilloscope to the hard drive in .CSV files. This example works with record length of any size supported by the scope. However, for recorded lengths approaching 1 million points or larger it is highly recommend that you modify the code to save the binary data directly to disk rather than convert it to .CSV as performance will become very slow due to the conversion time required to convert floating point numbers to text strings.
+This example shows how to use the Curve Streaming feature of MSO/DPO5000/B, DPO7000/C, DSA70000/B/C/D, and MSO70000/C/DX, DPO70000/B/C/D/DX /SX Series Digital Oscilloscopes to stream curves from the oscilloscope to the hard drive in text (.csv) or binary (.dat) files. This example works with record length of any size supported by the scope. However, for recorded lengths approaching 1 million points or larger it is highly recommend that you save the data in binary (.dat) format rather than text (.csv) as performance will become very slow due to the conversion time required to convert floating point numbers to text strings.
 
 Resources
 ---------
@@ -14,6 +14,7 @@ One Example, Two Versions
 Within this directory you will find two versions of the example.
 * *CurvestreamExample-NI-VISA*
   * Contains the original example as posted on the Tektronix forums.
+  * This version is deprecated and kept only for reference.  Please use the IVI-VISA.NET</nolink> version.
 * *CurvestreamExample-IVI-VISA<nolink/>.NET*
   * An updated version of the example that uses the IVI standard VISA<nolink/>.NET library.
 


### PR DESCRIPTION
Added the option to save to binary file format in addition to .csv file formats. Binary files are saved as an array of 32-bit floating point XY pairs.
Also updated the readme.

# Pull Request Checklist

Please review the [Contribution Guidelines](../README.md) before submitting.

- [x] Pulling against the `master` branch (left side).
- [x] You have previously submitted a [Contributor License Agreement](../README.md) or have contacted a maintainer to request one.

### Type (Select only one)

- [ ] Bug fix
- [x] Working example
- [ ] In-progress example (need Tektronix help)
- [ ] In-progress example (does not need Tektronix help)

### Description

Modified the Curvestream example to include saving the waveform data to binary format.  This is much quicker than saving to .csv format as was noted in the comments in the previous version of the example.  The example now includes actually saving to a binary format.

<!-- Modified by Tektronix. Original Content developed by the angular-translate team and Pascal Precht and their Pull Request Template available at https://github.com/angular-translate/angular-translate -->
