### PR TITLE
Added Fetch Waveform Data Example  for MSO/DPO 5K 7K & 70K

### DIFF
--- a/Examples/Oscilloscopes/PerformanceScopes/src/FetchWaveformDataExample/MSO DPO 5K 7K 70K Fetch Waveform Data.py
+++ b/Examples/Oscilloscopes/PerformanceScopes/src/FetchWaveformDataExample/MSO DPO 5K 7K 70K Fetch Waveform Data.py
@@ -1,0 +1,73 @@
+#-------------------------------------------------------------------------------
+# Name:  Fetch Waveform Data for MSO/DPO 5K 7K & 70K Series Scopes
+# Purpose:  This example demonstrates how to fetch waveform data from MSO/DSA/DPO
+# 5K, 7K & 70K Series Scopes, convert the raw data into floating point values and
+# then save it to disk in a binary format.
+#
+# Created:  2021-01-03
+#
+# Development Environment: Python 3.7, PyVisa 1.11, NI-VISA 18.5, Windows 10
+#
+# Compatible Instruments:
+#       MSO/DPO 5000(B) Series Oscilloscopes
+#       DPO7000(C) Series Oscilloscopes
+#       MSO/DSA/DPO 70000(B)(C)(DX)(SX) Series Oscilloscopes
+#
+# Compatible Interfaces:  USB, Ethernet
+#
+# Tektronix provides the following example "AS IS" with no support or warranty.
+#
+#-------------------------------------------------------------------------------
+
+import pyvisa as visa # https://pyvisa.readthedocs.io/en/latest/
+import numpy as np # https://numpy.org/
+
+# Modify the following line with the VISA resource address of your instrument
+visaResourceAddr = 'TCPIP0::<ip address>::inst0::INSTR'
+
+rm = visa.ResourceManager()
+scope = rm.open_resource(visaResourceAddr)
+
+print(scope.query('*IDN?'))
+scope.write("HEADER 0")
+scope.write("DATA:SOUR CH1")
+scope.write("DAT:ENC SRI")   # Signed Binary Format, LSB order
+scope.write("DAT:WIDTH 1")
+
+scope.write("DAT:START 1")
+scope.write("DAT:STOP 1e10") # Set data stop to max
+recordLength = int(scope.query("WFMO:NR_P?"))  # Query how many points are actually available
+scope.write("DAT:STOP {0}".format(recordLength)) # Set data stop to match points available
+
+# Fetch horizontal scaling factors
+xinc = float(scope.query("WFMO:XINCR?"))
+xzero = float(scope.query("WFMO:XZERO?"))
+pt_off = int(scope.query("WFMO:PT_OFF?"))
+
+# Fetch vertical scaling factors
+ymult = float(scope.query("WFMO:YMULT?"))
+yzero = float(scope.query("WFMO:YZERO?"))
+yoff = float(scope.query("WFMO:YOFF?"))
+
+# Fetch waveform data
+scope.write("curve?")
+
+# Data is sent back with ieee defined header.  ie. #41000<binary data bytes>\n
+# PyVISA read_binary_values() method will automatically read and parse the ieee block header so you don't have to.
+rawData = scope.read_binary_values(datatype='b', is_big_endian=False, container=np.ndarray, header_fmt='ieee', expect_termination=True)
+dataLen = len(rawData)
+
+# Create numpy arrays of floating point values for the X and Y axis
+t0 = (-pt_off * xinc) + xzero
+xvalues = np.ndarray(dataLen, np.float)
+yvalues = np.ndarray(dataLen, np.float)
+for i in range(0,dataLen):
+    xvalues[i] = t0 + xinc * i # Create timestamp for the data point
+    yvalues[i] = float(rawData[i] - yoff) * ymult + yzero # Convert raw ADC value into a floating point value
+
+# Save data to disk in binary format.  Can be read back from file using np.load()
+xvalues.dump(r"./xvalues_numpy_array.dat")
+yvalues.dump(r"./yvalues_numpy_array.dat")
+
+scope.close()
+rm.close()

--- a/Examples/Oscilloscopes/PerformanceScopes/src/FetchWaveformDataExample/README.md
+++ b/Examples/Oscilloscopes/PerformanceScopes/src/FetchWaveformDataExample/README.md
@@ -1,0 +1,15 @@
+# Fetch Waveform Data Example
+Original attribution: Dave W. - Tektronix Applications
+
+This example demonstrates how to fetch waveform data from MSO/DSA/DPO  5K 7K & 70K Series Scopes, convert the raw data into floating point values and then save it to disk in a binary format.
+
+Compatible Instruments
+----------------------
+* MSO/DPO 5000(B) Series Oscilloscopes
+* DPO7000(C) Series Oscilloscopes
+* MSO/DSA/DPO 70000(B)(C)(DX)(SX) Series Oscilloscopes
+
+Resources
+---------
+Original Discussion:
+https://forum.tek.com/viewtopic.php?t=142911

--- a/Examples/Oscilloscopes/PerformanceScopes/src/FetchWaveformDataExample/README.md
+++ b/Examples/Oscilloscopes/PerformanceScopes/src/FetchWaveformDataExample/README.md
@@ -9,6 +9,7 @@ Compatible Instruments
 * DPO7000(C) Series Oscilloscopes
 * MSO/DSA/DPO 70000(B)(C)(DX)(SX) Series Oscilloscopes
 
+<!-- markdown-link-check-disable -->
 Resources
 ---------
 Original Discussion:


### PR DESCRIPTION
Added Fetch Waveform Data for MSO/DPO 5K 7K & 70K Series Scopes Python example

# Pull Request Checklist

Please review the [Contribution Guidelines](../README.md) before submitting.

- [x] Pulling against the `master` branch (left side).
- [x] You have previously submitted a [Contributor License Agreement](../README.md) or have contacted a maintainer to request one.

### Type (Select only one)

- [ ] Bug fix
- [x] Working example
- [ ] In-progress example (need Tektronix help)
- [ ] In-progress example (does not need Tektronix help)

### Description

Created an example that demonstrates how to fetch waveform data from 5K, 7K and 70K Series scopes, convert the raw values to floating point and then save the data to disk in a binary format using Python 3.

<!-- Modified by Tektronix. Original Content developed by the angular-translate team and Pascal Precht and their Pull Request Template available at https://github.com/angular-translate/angular-translate -->
